### PR TITLE
chore: Pull v2.0.x changes to v2.1.x

### DIFF
--- a/deployments/compose/docker-compose.dev.yml
+++ b/deployments/compose/docker-compose.dev.yml
@@ -3,26 +3,24 @@
 # Stores the node config in a docker "volume", which should be
 # reset between testnets: `docker volume rm compose_penumbra-pd-node0` or similar.
 # See docs for details:  https://guide.penumbra.zone/main/pd/join-testnet.html
-
+#
 # N.B. the "latest" tag for Penumbra container images maps to the latest
 # tagged release; use "main" tag for tracking the rolling preview networks.
-version: "3.7"
 services:
 
   # Initialize node config, via `pd testnet join`.
   pd-node0-init:
-    platform: "linux/amd64"
     image: ghcr.io/penumbra-zone/penumbra:latest
     command: >-
       sh -c
       "
       pd --version &&
       if ! test -e /pd/testnet_data/node0/cometbft/config/config.toml ; then
-          >&2 printf 'WARN: testnet config not found. Creating fresh node identity.'
-          >&2 echo ' See docs for details: https://guide.penumbra.zone/main/pd/join-testnet.html'
-          /bin/pd testnet --testnet-dir /pd/testnet_data generate
+        >&2 printf 'WARN: testnet config not found. Creating fresh node identity.'
+        >&2 echo ' See docs for details: https://guide.penumbra.zone/main/pd/join-testnet.html'
+        /bin/pd testnet --testnet-dir /pd/testnet_data generate
       else
-          >&2 echo 'Node config already found, using it'
+        >&2 echo 'Node config already found, using it'
       fi &&
       chown 100 -R /pd/testnet_data/node0/cometbft &&
       chown 1000 -R /pd/testnet_data/node0/pd &&
@@ -36,10 +34,9 @@ services:
 
   # The Penumbra daemon
   pd-node0:
-    platform: "linux/amd64"
     image: ghcr.io/penumbra-zone/penumbra:latest
-      # consider verbose debugging logs:
-      # environment:
+    # consider verbose debugging logs:
+    # environment:
     # RUST_LOG: h2=off,debug
     command: >-
       /bin/pd start --home /pd/testnet_data/node0/pd

--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -12,21 +12,29 @@ services:
   # Initialize node config, via `pd network join`.
   pd-node0-init:
     platform: "linux/amd64"
-    image: ghcr.io/penumbra-zone/penumbra:latest
+    # just container
+    image: ghcr.io/penumbra-zone/penumbra:local
     command: >-
       sh -c
       "
       pd --version &&
       if ! test -e /pd/network_data/node0/cometbft/config/config.toml ; then
-          >&2 printf 'WARN: network config not found. Creating fresh node identity.'
-          >&2 echo ' See docs for details: https://guide.penumbra.zone/node/pd/join-network.html
-          /bin/pd network --network-dir /pd/network_data join
+          >&2 printf 'WARN: network config not found. Creating fresh local network.\n'
+          # --allocation-address is mnemonic 'test test test test test test test test test test test junk' (commonly used in Ethereum)
+          rm -rf /pd/network_data &&
+          /bin/pd network --network-dir /pd/network_data generate --chain-id penumbra-local-devnet --preserve-chain-id --gas-price-simple 0 --unbonding-delay 302400 --epoch-duration 302400 --proposal-voting-blocks 50 --timeout-commit 500ms --allocation-address "penumbra1eu5pnv6qptp2p0aevfc0adjrpd24glz5shey7wvwlg5sp3ffca2zk32cemjd90ughdh7xqplrej9lqzc06337w2scxykjajd2nrtttvmqt6tssr6pmzp283hhte7y4jf6sn2wh"
       else
           >&2 echo 'Node config already found, using it'
       fi &&
-      chown 100 -R /pd/network_data/node0/cometbft &&
-      chown 1000 -R /pd/network_data/node0/pd &&
-      ls -l /pd/network_data/node0/ && exit 0
+      if test -d /pd/network_data/node0 ; then
+          mkdir -p /pd/network_data/node0/cometbft/data &&
+          chown 100 -R /pd/network_data/node0/cometbft &&
+          chown 1000 -R /pd/network_data/node0/pd &&
+          ls -l /pd/network_data/node0/ && exit 0
+      else
+          >&2 echo 'ERROR: network generation failed'
+          exit 1
+      fi
       "
     restart: on-failure
     volumes:
@@ -37,7 +45,7 @@ services:
   # The Penumbra daemon
   pd-node0:
     platform: "linux/amd64"
-    image: ghcr.io/penumbra-zone/penumbra:latest
+    image: ghcr.io/penumbra-zone/penumbra:local
     # consider verbose debugging logs:
     # environment:
       # RUST_LOG: h2=off,debug
@@ -49,6 +57,7 @@ services:
     volumes:
       - penumbra-pd-node0:/pd
     user: "${UID:-1000}"
+    stop_signal: SIGKILL
     depends_on:
       - pd-node0-init
     ports:
@@ -63,6 +72,7 @@ services:
       - "26657:26657"
     volumes:
       - penumbra-pd-node0:/cometbft
+    user: "100"
     environment:
       CMTHOME: /cometbft/network_data/node0/cometbft
     command: start --proxy_app=tcp://pd-node0:26658

--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -3,37 +3,34 @@
 # Stores the node config in a docker "volume", which should be
 # reset between networks: `docker volume rm compose_penumbra-pd-node0` or similar.
 # See docs for details:  https://guide.penumbra.zone/node/pd/join-network.html
-
+#
 # N.B. the "latest" tag for Penumbra container images maps to the latest
 # tagged release; use "main" tag for tracking the rolling preview networks.
-version: "3.7"
 services:
 
   # Initialize node config, via `pd network join`.
   pd-node0-init:
-    platform: "linux/amd64"
-    # just container
     image: ghcr.io/penumbra-zone/penumbra:local
     command: >-
       sh -c
       "
       pd --version &&
       if ! test -e /pd/network_data/node0/cometbft/config/config.toml ; then
-          >&2 printf 'WARN: network config not found. Creating fresh local network.\n'
-          # --allocation-address is mnemonic 'test test test test test test test test test test test junk' (commonly used in Ethereum)
-          rm -rf /pd/network_data &&
-          /bin/pd network --network-dir /pd/network_data generate --chain-id penumbra-local-devnet --preserve-chain-id --gas-price-simple 0 --unbonding-delay 302400 --epoch-duration 302400 --proposal-voting-blocks 50 --timeout-commit 500ms --allocation-address "penumbra1eu5pnv6qptp2p0aevfc0adjrpd24glz5shey7wvwlg5sp3ffca2zk32cemjd90ughdh7xqplrej9lqzc06337w2scxykjajd2nrtttvmqt6tssr6pmzp283hhte7y4jf6sn2wh"
+        >&2 printf 'WARN: network config not found. Creating fresh local network.\n'
+        # --allocation-address is mnemonic 'test test test test test test test test test test test junk' (commonly used in Ethereum)
+        rm -rf /pd/network_data &&
+        /bin/pd network --network-dir /pd/network_data generate --chain-id penumbra-local-devnet --preserve-chain-id --gas-price-simple 0 --unbonding-delay 302400 --epoch-duration 302400 --proposal-voting-blocks 50 --timeout-commit 500ms --allocation-address "penumbra1eu5pnv6qptp2p0aevfc0adjrpd24glz5shey7wvwlg5sp3ffca2zk32cemjd90ughdh7xqplrej9lqzc06337w2scxykjajd2nrtttvmqt6tssr6pmzp283hhte7y4jf6sn2wh"
       else
-          >&2 echo 'Node config already found, using it'
+        >&2 echo 'Node config already found, using it'
       fi &&
       if test -d /pd/network_data/node0 ; then
-          mkdir -p /pd/network_data/node0/cometbft/data &&
-          chown 100 -R /pd/network_data/node0/cometbft &&
-          chown 1000 -R /pd/network_data/node0/pd &&
-          ls -l /pd/network_data/node0/ && exit 0
+        mkdir -p /pd/network_data/node0/cometbft/data &&
+        chown 100 -R /pd/network_data/node0/cometbft &&
+        chown 1000 -R /pd/network_data/node0/pd &&
+        ls -l /pd/network_data/node0/ && exit 0
       else
-          >&2 echo 'ERROR: network generation failed'
-          exit 1
+        >&2 echo 'ERROR: network generation failed'
+        exit 1
       fi
       "
     restart: on-failure
@@ -44,11 +41,10 @@ services:
 
   # The Penumbra daemon
   pd-node0:
-    platform: "linux/amd64"
     image: ghcr.io/penumbra-zone/penumbra:local
     # consider verbose debugging logs:
     # environment:
-      # RUST_LOG: h2=off,debug
+    # RUST_LOG: h2=off,debug
     command: >-
       /bin/pd start --home /pd/network_data/node0/pd
       --grpc-bind 0.0.0.0:8080 --abci-bind 0.0.0.0:26658

--- a/deployments/scripts/run-local-devnet.sh
+++ b/deployments/scripts/run-local-devnet.sh
@@ -17,13 +17,15 @@ cargo --quiet run --release --bin pd -- --help > /dev/null
 if [[ -d ~/.penumbra/network_data ]] ; then
     >&2 echo "network data exists locally, reusing it"
 else
+    # XXX: Manually Add allocation address.
     cargo run --release --bin pd -- network generate \
         --chain-id penumbra-local-devnet \
-        --unbonding-delay 50 \
-        --epoch-duration 50 \
+        --unbonding-delay 302400 \
+        --epoch-duration 302400 \
         --proposal-voting-blocks 50 \
-        --gas-price-simple 500 \
-        --timeout-commit 500ms
+        --gas-price-simple 0 \
+        --timeout-commit 500ms \
+        --allocation-address "penumbra1cvp32r5wp4lfnnww3g3fytxccqnu2xcj0r2qm0sa8ekjdezlm3gzk34qtg2xscqx9r6yrhz24k3l6j88q98rexyp7dnupq66cxllvpp9v0lw0xuqf0yfhv5ksfxzv0m968tmxn"
     # opt in to cometbft abci indexing to postgres
     postgresql_db_url="postgresql://penumbra:penumbra@localhost:5432/penumbra_cometbft?sslmode=disable"
     sed -i -e "s#^indexer.*#indexer = \"psql\"\\npsql-conn = \"$postgresql_db_url\"#" ~/.penumbra/network_data/node0/cometbft/config/config.toml

--- a/justfile
+++ b/justfile
@@ -89,4 +89,14 @@ integration-pd:
 
 # Build the container image locally
 container:
-  podman build -t ghcr.io/penumbra-zone/penumbra -f ./deployments/containerfiles/Dockerfile .
+  docker build -t ghcr.io/penumbra-zone/penumbra:local -f ./deployments/containerfiles/Dockerfile .
+
+# Run the testnet locally entirely
+testnet:
+  just --justfile {{justfile()}} testnet-clean
+  docker compose -f deployments/compose/docker-compose.yml up
+
+# clean up the testnet, removing all volumes
+testnet-clean:
+  docker compose -f deployments/compose/docker-compose.yml down --volumes
+  docker volume rm compose_penumbra-pd-node0 --force || true


### PR DESCRIPTION
Push changes found in our fork (v2.0.x) to the new v2.1.x release branch.

Note, when executing `just container`, I'm seeing the following error: https://pastebin.com/1ynVb7gi