### PR TITLE
fix(shielded-pool): bind unregulated transfer statements to the neighbor leaf

### DIFF
--- a/crates/core/component/compliance/src/lib.rs
+++ b/crates/core/component/compliance/src/lib.rs
@@ -120,6 +120,7 @@ pub use decode_object::{
 pub mod upload_package;
 pub use upload_package::{
     build_orbis_encrypted_seed_upload_package,
+    build_orbis_encrypted_seed_upload_package_from_statement,
     build_orbis_encrypted_seed_upload_package_with_randomness, decrypt_orbis_reencrypted_seed,
     encode_orbis_policy_metadata, OrbisEncryptedSeedUploadPackage, OrbisSecretEnvelope,
     TransferOrbisUploadBundle,

--- a/crates/core/component/compliance/src/upload_package.rs
+++ b/crates/core/component/compliance/src/upload_package.rs
@@ -285,8 +285,6 @@ pub fn build_orbis_encrypted_seed_upload_package_with_randomness(
     timestamp: u64,
     salt: Fq,
 ) -> Result<OrbisEncryptedSeedUploadPackage> {
-    statement.validate_shape()?;
-    let derivation_bytes = statement.subject_b_d_bytes;
     anyhow::ensure!(
         string_to_fq(ring_id) == statement.ring_id_hash()?,
         "ring_id does not match statement ring_id_hash"
@@ -303,6 +301,37 @@ pub fn build_orbis_encrypted_seed_upload_package_with_randomness(
         string_to_fq(permission) == statement.permission_hash()?,
         "permission does not match statement permission_hash"
     );
+    build_orbis_encrypted_seed_upload_package_from_statement(
+        rng, ring_pk, seed, r, statement, ring_id, policy_id, resource, permission, tier,
+        timestamp, salt,
+    )
+}
+
+/// Like [`build_orbis_encrypted_seed_upload_package_with_randomness`], but
+/// trusts the statement's metadata hashes instead of requiring them to equal
+/// the hashes of the string identifiers.
+///
+/// Unregulated transfers need this: the transfer circuit binds each tier
+/// statement's metadata hashes to the asset indexed leaf, and for an
+/// unregulated asset that leaf is the non-membership *neighbor* — a real
+/// registered asset whose identifier strings the client does not know, only
+/// their hashes from the leaf.
+pub fn build_orbis_encrypted_seed_upload_package_from_statement(
+    rng: &mut (impl RngCore + CryptoRng),
+    ring_pk: &Element,
+    seed: Fq,
+    r: Fr,
+    statement: TransferTierMetadataStatement,
+    ring_id: &str,
+    policy_id: &str,
+    resource: &str,
+    permission: &str,
+    tier: TransferTierKind,
+    timestamp: u64,
+    salt: Fq,
+) -> Result<OrbisEncryptedSeedUploadPackage> {
+    statement.validate_shape()?;
+    let derivation_bytes = statement.subject_b_d_bytes;
     anyhow::ensure!(statement.tier == tier, "tier does not match statement tier");
     anyhow::ensure!(
         statement.target_timestamp == timestamp,

--- a/crates/core/component/shielded-pool/src/transfer/compliance.rs
+++ b/crates/core/component/shielded-pool/src/transfer/compliance.rs
@@ -2,10 +2,10 @@ use anyhow::{anyhow, ensure, Result};
 use decaf377::Fr;
 use penumbra_sdk_asset::Value;
 use penumbra_sdk_compliance::{
-    build_orbis_encrypted_seed_upload_package_with_randomness, derive_transfer_salt,
-    encrypt_transfer, AssetPolicy, IndexedLeaf, TransferComplianceCiphertext,
-    TransferCompliancePublicInputs, TransferOrbisUploadBundle, TransferTierKind,
-    TransferTierMetadataStatement, TRANSFER_WIRE_BYTES,
+    build_orbis_encrypted_seed_upload_package_from_statement, derive_transfer_salt,
+    encrypt_transfer, indexed_tree::string_to_fq, AssetPolicy, IndexedLeaf,
+    TransferComplianceCiphertext, TransferCompliancePublicInputs, TransferOrbisUploadBundle,
+    TransferTierKind, TransferTierMetadataStatement, TRANSFER_WIRE_BYTES,
 };
 use rand::{rngs::StdRng, SeedableRng};
 
@@ -114,19 +114,41 @@ pub(crate) fn build_transfer_compliance(
     let ring_id = &asset_policy.ring.ring_id;
     let resource = &asset_policy.ring.resource;
     let permission = &asset_policy.ring.permission;
+    // The transfer circuit binds each tier statement's metadata hashes to the
+    // asset indexed leaf. For a regulated asset that leaf is the asset's own
+    // (hashes == hashes of the policy strings). For an unregulated asset the
+    // leaf is the non-membership *neighbor* — a real registered asset whose
+    // identifier strings the client does not know — so the dummy statements
+    // must carry the neighbor leaf's hashes verbatim or proving fails.
+    let (ring_id_hash, policy_id_hash, resource_hash, permission_hash) =
+        if receiver_output.is_regulated {
+            (
+                string_to_fq(ring_id),
+                string_to_fq(policy_id),
+                string_to_fq(resource),
+                string_to_fq(permission),
+            )
+        } else {
+            (
+                asset_indexed_leaf.ring.ring_id_hash,
+                asset_indexed_leaf.ring.policy_id_hash,
+                asset_indexed_leaf.ring.resource_hash,
+                asset_indexed_leaf.ring.permission_hash,
+            )
+        };
     let mut upload_rng = StdRng::from_seed(transfer_orbis_upload_rng_seed(transfer_nonce_root));
     let bundle = TransferOrbisUploadBundle {
-        sender_core: build_orbis_encrypted_seed_upload_package_with_randomness(
+        sender_core: build_orbis_encrypted_seed_upload_package_from_statement(
             &mut upload_rng,
             &ring_pk,
             encryption.sender.core.seed,
             encryption.sender.core.r,
-            TransferTierMetadataStatement::from_identifiers(
+            TransferTierMetadataStatement::new(
                 sender_b_d,
-                ring_id,
-                policy_id,
-                resource,
-                permission,
+                ring_id_hash,
+                policy_id_hash,
+                resource_hash,
+                permission_hash,
                 TransferTierKind::SenderCore,
                 target_timestamp,
                 sender_core_salt,
@@ -139,17 +161,17 @@ pub(crate) fn build_transfer_compliance(
             target_timestamp,
             sender_core_salt,
         )?,
-        sender_ext: build_orbis_encrypted_seed_upload_package_with_randomness(
+        sender_ext: build_orbis_encrypted_seed_upload_package_from_statement(
             &mut upload_rng,
             &ring_pk,
             encryption.sender.ext.seed,
             encryption.sender.ext.r,
-            TransferTierMetadataStatement::from_identifiers(
+            TransferTierMetadataStatement::new(
                 sender_b_d,
-                ring_id,
-                policy_id,
-                resource,
-                permission,
+                ring_id_hash,
+                policy_id_hash,
+                resource_hash,
+                permission_hash,
                 TransferTierKind::SenderExt,
                 target_timestamp,
                 sender_ext_salt,
@@ -162,17 +184,17 @@ pub(crate) fn build_transfer_compliance(
             target_timestamp,
             sender_ext_salt,
         )?,
-        output_core: build_orbis_encrypted_seed_upload_package_with_randomness(
+        output_core: build_orbis_encrypted_seed_upload_package_from_statement(
             &mut upload_rng,
             &ring_pk,
             encryption.output.core.seed,
             encryption.output.core.r,
-            TransferTierMetadataStatement::from_identifiers(
+            TransferTierMetadataStatement::new(
                 receiver_b_d,
-                ring_id,
-                policy_id,
-                resource,
-                permission,
+                ring_id_hash,
+                policy_id_hash,
+                resource_hash,
+                permission_hash,
                 TransferTierKind::OutputCore,
                 target_timestamp,
                 output_core_salt,
@@ -185,17 +207,17 @@ pub(crate) fn build_transfer_compliance(
             target_timestamp,
             output_core_salt,
         )?,
-        output_ext: build_orbis_encrypted_seed_upload_package_with_randomness(
+        output_ext: build_orbis_encrypted_seed_upload_package_from_statement(
             &mut upload_rng,
             &ring_pk,
             encryption.output.ext.seed,
             encryption.output.ext.r,
-            TransferTierMetadataStatement::from_identifiers(
+            TransferTierMetadataStatement::new(
                 receiver_b_d,
-                ring_id,
-                policy_id,
-                resource,
-                permission,
+                ring_id_hash,
+                policy_id_hash,
+                resource_hash,
+                permission_hash,
                 TransferTierKind::OutputExt,
                 target_timestamp,
                 output_ext_salt,


### PR DESCRIPTION
Fixes the client half of mizufinance/shieldd-web#4 for the pre-grants (bankd demo) line — targeting `bankd-demo`, a new branch at the exact commit the demo stack's wasm builds pin (`f6cdf12`, previously dangling).

## Problem

Private transfers of assets with **no compliance-tree entry** always fail proving:

```
prove transfer: constraint #144774 is not satisfied
```

The gnark transfer circuit's `verifyProofStatement` unconditionally asserts each compliance tier statement's ring/policy/resource/permission hashes equal the asset indexed leaf's. For a regulated transfer the leaf is the asset's own, so statements built from the policy strings match. For an unregulated transfer the leaf is the **non-membership neighbor** — a real registered asset with real metadata hashes — while the client built its dummy statements from `AssetPolicy::default_unregulated()`'s empty strings.

## Fix (client-side only)

Build the tier statements from the indexed leaf's hashes directly when the transfer is unregulated (the identifier strings behind them are unknown client-side; only the hashes from the leaf). This is consistent everywhere without circuit/artifact/pd changes:

- the DLEQ metadata hash derives from the statement,
- pd recomputes the public-input hash from the statement as carried in the action body,
- unregulated bundles are never uploaded to ORBIS.

Adds `build_orbis_encrypted_seed_upload_package_from_statement`, which trusts the statement hashes instead of requiring them to match the string identifiers; the existing checked builder delegates to it.

## Verification

On the bankd localnet with the pinned pd/prover images (wasm rebuilt as `53.0.1-bankd-demo.3`): the previously-failing unregulated private send proves (prover 200) and confirms on-chain; the regulated transfer e2e (4 ORBIS StoreSecret uploads + broadcast confirmation) still passes.

For the shieldd (grants/slot) line the preferred fix is in-circuit — select leaf hashes vs. the empty-string constants on `IsRegulated`, mirroring the existing key selection — see the follow-ups on mizufinance/shieldd-web#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)