### PR TITLE
fix(compliance): accept unregulated transfer bundles in stateless check

### DIFF
--- a/crates/core/component/compliance/src/upload_package.rs
+++ b/crates/core/component/compliance/src/upload_package.rs
@@ -130,22 +130,34 @@ impl OrbisEncryptedSeedUploadPackage {
 
     pub fn validate(&self) -> Result<()> {
         self.statement.validate_shape()?;
-        anyhow::ensure!(
-            string_to_fq(&self.ring_id) == self.statement.ring_id_hash()?,
-            "ring_id does not match statement ring_id_hash"
-        );
-        anyhow::ensure!(
-            string_to_fq(&self.policy_id) == self.statement.policy_id_hash()?,
-            "policy_id does not match statement policy_id_hash"
-        );
-        anyhow::ensure!(
-            string_to_fq(&self.resource) == self.statement.resource_hash()?,
-            "resource does not match statement resource_hash"
-        );
-        anyhow::ensure!(
-            string_to_fq(&self.permission) == self.statement.permission_hash()?,
-            "permission does not match statement permission_hash"
-        );
+        // The ring identifier strings hash to the statement's ring metadata
+        // hashes ONLY for regulated bundles, where those hashes come from the
+        // asset's own leaf. For an unregulated transfer the statement carries
+        // the non-membership neighbor leaf's hashes (so the transfer circuit
+        // verifies), while these identifier strings are the empty sink — the
+        // client cannot know the neighbor's strings, only its hashes. Skip the
+        // string==hash consistency check in that case; the statement hashes
+        // remain cryptographically bound by the DLEQ below, and unregulated
+        // bundles carry no ORBIS routing metadata to check anyway.
+        let is_unregulated_sink = self.ring_id.is_empty();
+        if !is_unregulated_sink {
+            anyhow::ensure!(
+                string_to_fq(&self.ring_id) == self.statement.ring_id_hash()?,
+                "ring_id does not match statement ring_id_hash"
+            );
+            anyhow::ensure!(
+                string_to_fq(&self.policy_id) == self.statement.policy_id_hash()?,
+                "policy_id does not match statement policy_id_hash"
+            );
+            anyhow::ensure!(
+                string_to_fq(&self.resource) == self.statement.resource_hash()?,
+                "resource does not match statement resource_hash"
+            );
+            anyhow::ensure!(
+                string_to_fq(&self.permission) == self.statement.permission_hash()?,
+                "permission does not match statement permission_hash"
+            );
+        }
         anyhow::ensure!(
             self.tier_label == self.statement.tier.label(),
             "tier_label does not match statement tier"


### PR DESCRIPTION
Completes the unregulated-transfer fix for the pre-grants (bankd demo) line. Stacks on #100 (targets `bankd-demo`).

## Problem

After #100 (statement hashes bound to the non-membership neighbor leaf so the transfer circuit verifies), private-to-private transfers of assets **absent from the compliance tree** proved successfully but were then rejected at broadcast:

```
transfer extract public failed: ring_id does not match statement ring_id_hash
```

`OrbisEncryptedSeedUploadPackage::validate()` — run by pd's transfer `check_stateless` (`parse_transfer_output_compliance`) and by client-side bundle decoding — requires each tier's ring/policy/resource/permission identifier **string** to hash to the statement's corresponding hash. That holds for regulated bundles (hashes come from the asset's own leaf) but not for unregulated transfers: there the statement carries the neighbor leaf's hashes while the identifier strings are the empty sink. The client cannot know the neighbor's strings, only its hashes, so the two can never be made consistent for an unregistered asset.

## Fix

Skip the four `string == hash` consistency checks when the bundle is the unregulated sink (empty `ring_id`). Everything else in `validate()` still runs — shape validation, the transfer DLEQ, and the ORBIS-metadata DLEQ — so the statement hashes remain cryptographically bound. Unregulated bundles carry no ORBIS routing and are never uploaded, so the identifier strings are informational only. Regulated bundles (non-empty `ring_id`) are unchanged.

This mirrors the split already made on the build side in #100 (`build_orbis_encrypted_seed_upload_package_from_statement` trusts the statement hashes instead of requiring string==hash).

## Verification

On the bankd localnet with a pd image built from this branch (`penumbra:local`):

- Private-to-private send of a freshly-deployed, never-registered ERC20 voucher: **proves and confirms on-chain** (previously rejected here).
- Regulated transfer e2e (registration → 4 ORBIS StoreSecret uploads → broadcast): still passes.

## Deployment note

This changes pd's stateless logic, so demo stacks need an image built from this branch (`PENUMBRA_IMAGE=penumbra:local`) rather than the stock pin; the gnark prover artifacts are unchanged. On the shieldd (grants/slot) line the cleaner form is the in-circuit statement selection tracked in mizufinance/shieldd-web#4, which removes the string==hash tension at its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)