### PR TITLE
ci: v16 -> v8

### DIFF
--- a/.github/workflows/orbis-integration.yml
+++ b/.github/workflows/orbis-integration.yml
@@ -39,11 +39,11 @@ jobs:
   flow:
     needs: applicability
     if: needs.applicability.result == 'success' && needs.applicability.outputs.run == 'true'
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 45
     concurrency:
       group: orbis-integration-host-stack-v1
-      cancel-in-progress: false
+      cancel-in-progress: true
     env:
       COMPLIANCE_TMP: /tmp/orbis-${{ github.run_id }}-${{ github.run_attempt }}
       SHIELDD_PD_GRPC_PORT: "28080"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -48,7 +48,7 @@ jobs:
   smoke:
     needs: paths
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' || needs.paths.outputs.smoke == 'true'
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     env:
       SHIELDD_PD_GRPC_PORT: "18080"
       SHIELDD_COMETBFT_RPC_PORT: "17657"


### PR DESCRIPTION
## Describe your changes

We are still burning a lot of blacksmith CPUs per day, need to cut back from v16

@AntoineCyr can we move that `snarkpack: runtime` to the scheduled daily instead of on every PR? same for any heavy provers. Just trying to see what is absolutely the requirement vs just nice to have given cost